### PR TITLE
Optionally Separate Init Dir

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
-# allow a user to change the shared folder
+# allow a user to change the shared folder location
 vagrant_shared_folder: /vagrant
+# allow a user to change where the initial cd on login points to
+vagrant_init_dir: "{{ vagrant_shared_folder }}"
+# additional utility packages
 vagrant_utility_packages: []

--- a/templates/vagrant-magic.sh.j2
+++ b/templates/vagrant-magic.sh.j2
@@ -1,4 +1,4 @@
 if [ $(history 2>/dev/null | wc -l) -eq 0 ]; then
   # we've just shelled in; "magically" cd into the vagrant shared folder
-  cd "{{ vagrant_shared_folder }}"
+  cd "{{ vagrant_init_dir }}"
 fi


### PR DESCRIPTION
Allow specifying a different initial directory to be cd'd into, this is useful for the Go role.